### PR TITLE
Start addressing response data by their numeric address in the message datagram

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -117,43 +117,49 @@ Battery states:
 
 **Response message :**
 
-| Address in message block | Length   | Meaning                 | Data type                                 |
-|--------------------------|----------|-------------------------|-------------------------------------------|
-| 0-1                      | 2 bytes  | PV1 voltage.            | unsigned int16 fractional (scaling 1/10)  |
-| 2-3                      | 2 bytes  | PV1 current.            | unsigned int16 fractional (scaling 1/10)  |
-| 4-5                      | 2 bytes  | PV1 power.              | unsigned int16                            |
-| 6-7                      | 2 bytes  | PV2 voltage.            | unsigned int16 fractional (scaling 1/10)  |
-| 8-9                      | 2 bytes  | PV2 current.            | unsigned int16 fractional (scaling 1/10)  |
-| 10-11                    | 2 bytes  | PV2 power.              | unsigned int16                            |
-| 12-17                    | 6 bytes  | ??                      | ??                                        |
-| 18-19                    | 2 bytes  | AB line voltage         | unsigned int16 fractional (scaling 1/10)  |
-| 20-21                    | 2 bytes  | A phase current.        | unsigned int16 fractional (scaling 1/10)  |
-| 22-25                    | 4 bytes  | ??                      | ??                                        |
-| 26-27                    | 2 bytes  | A phase voltage.        | unsigned int16 fractional (scaling 1/10)  |
-| 28-29                    | 2 bytes  | BC line voltage.        | unsigned int16 fractional (scaling 1/10)  |
-| 30-31                    | 2 bytes  | B phase current.        | unsigned int16 fractional (scaling 1/10)  |
-| 32-33                    | 2 bytes  | B phase voltage.        | unsigned int16 fractional (scaling 1/10)  |
-| 34-35                    | 2 bytes  | ??                      | ??                                        |
-| 36-37                    | 2 bytes  | C phase voltage.        | unsigned int16 fractional (scaling 1/10)  |
-| 38-39                    | 2 bytes  | CA line voltage.        | unsigned int16 fractional (scaling 1/10)  |
-| 40-41                    | 2 bytes  | C phase current.        | unsigned int16 fractional (scaling 1/10)  |
-| 42-43                    | 2 bytes  | Grid (mains) frequency. | unsigned int16 fractional (scaling 1/100) |
-| 44-45                    | 2 bytes  | ??                      | ??                                        |
-| 46-47                    | 2 bytes  | Grid active power.      | signed int16                              |
-| 48-49                    | 2 bytes  | Grid reactive power.    | signed int16                              |
-| 50-51                    | 2 bytes  | Grid apparent power.    | signed int16                              |
-| 52-89                    | 38 bytes | ??                      | ??                                        |
-| 90-91                    | 2 bytes  | Backup Phase A voltage. | unsigned int16 fractional (scaling 1/10)  |
-| 92-93                    | 2 bytes  | Backup Phase B voltage. | unsigned int16 fractional (scaling 1/10)  |
-| 94-95                    | 2 bytes  | Backup Phase C voltage. | unsigned int16 fractional (scaling 1/10)  |
-| 96-97                    | 2 bytes  | Backup frequency.       | unsigned int16 fractional (scaling 1/100) |
-| 98-99                    | 2 bytes  | Backup Phase A current. | unsigned int16 fractional (scaling 1/10)  |
-| 100-101                  | 2 bytes  | Backup Phase B current. | unsigned int16 fractional (scaling 1/10)  |
-| 102-103                  | 2 bytes  | Backup Phase C current. | unsigned int16 fractional (scaling 1/10)  |
-| 104-105                  | 2 bytes  | ??                      | ??                                        |
-| 106-107                  | 2 bytes  | Backup active power.    | signed int16                              |
-| 108-109                  | 2 bytes  | Backup reactive power.  | signed int16                              |
-| 110-111                  | 2 bytes  | Backup apparent power.  | signed int16                              |
+| Address in message block | Length   | Meaning                   | Data type                                 |
+|--------------------------|----------|---------------------------|-------------------------------------------|
+| 0-1                      | 2 bytes  | PV1 voltage.              | unsigned int16 fractional (scaling 1/10)  |
+| 2-3                      | 2 bytes  | PV1 current.              | unsigned int16 fractional (scaling 1/10)  |
+| 4-5                      | 2 bytes  | PV1 power.                | unsigned int16                            |
+| 6-7                      | 2 bytes  | PV2 voltage.              | unsigned int16 fractional (scaling 1/10)  |
+| 8-9                      | 2 bytes  | PV2 current.              | unsigned int16 fractional (scaling 1/10)  |
+| 10-11                    | 2 bytes  | PV2 power.                | unsigned int16                            |
+| 12-13                    | 2 bytes  | Inverter Phase A voltage. | unsigned int16 fractional (scaling 1/10)  |
+| 14-15                    | 2 bytes  | Inverter Phase A current. | signed int16 fractional (scaling 1/10)    |
+| 16-17                    | 2 bytes  | Grid Phase A voltage.     | unsigned int16 fractional (scaling 1/10)  |
+| 18-19                    | 2 bytes  | Grid Line AB voltage.     | unsigned int16 fractional (scaling 1/10)  |
+| 20-21                    | 2 bytes  | Grid phase A current.     | signed int16 fractional (scaling 1/10)    |
+| 22-23                    | 2 bytes  | Inverter Phase B voltage. | unsigned int16 fractional (scaling 1/10)  |
+| 24-25                    | 2 bytes  | Inverter Phase B current. | signed int16 fractional (scaling 1/10)    |
+| 26-27                    | 2 bytes  | Grid Phase B voltage.     | unsigned int16 fractional (scaling 1/10)  |
+| 28-29                    | 2 bytes  | Grid line BC voltage.     | unsigned int16 fractional (scaling 1/10)  |
+| 30-31                    | 2 bytes  | Grid Phase B current.     | signed int16 fractional (scaling 1/10)    |
+| 32-23                    | 2 bytes  | Inverter Phase C voltage. | unsigned int16 fractional (scaling 1/10)  |
+| 34-35                    | 2 bytes  | Inverter Phase C current. | signed int16 fractional (scaling 1/10)    |
+| 36-37                    | 2 bytes  | Grid Phase C voltage.     | unsigned int16 fractional (scaling 1/10)  |
+| 38-39                    | 2 bytes  | Grid line CA voltage.     | unsigned int16 fractional (scaling 1/10)  |
+| 40-41                    | 2 bytes  | Grid Phase C current.     | signed int16 fractional (scaling 1/10)    |
+| 42-43                    | 2 bytes  | Grid (mains) frequency.   | unsigned int16 fractional (scaling 1/100) |
+| 44-45                    | 2 bytes  | Power Factor              | signed int16 fractional (scaling 1/1000)  |
+| 46-47                    | 2 bytes  | Grid active power.        | signed int16                              |
+| 48-49                    | 2 bytes  | Grid reactive power.      | signed int16                              |
+| 50-51                    | 2 bytes  | Grid apparent power.      | signed int16                              |
+| 52-69                    | 16 bytes | ??                        | ??                                        |
+ | 70-71                    | 2 bytes  | Device Type Code          | unsigned int16                            |
+ | 72-73                    | 2 bytes  | DSP Version High          | unsigned int16                            |
+ | 74-75                    | 2 bytes  | DSP Version Low           | unsigned int16                            |
+| 90-91                    | 2 bytes  | Load Phase A voltage.     | unsigned int16 fractional (scaling 1/10)  |
+| 92-93                    | 2 bytes  | Load Phase B voltage.     | unsigned int16 fractional (scaling 1/10)  |
+| 94-95                    | 2 bytes  | Load Phase C voltage.     | unsigned int16 fractional (scaling 1/10)  |
+| 96-97                    | 2 bytes  | Load frequency.           | unsigned int16 fractional (scaling 1/100) |
+| 98-99                    | 2 bytes  | Load Phase A current.     | signed int16 fractional (scaling 1/10)    |
+| 100-101                  | 2 bytes  | Load Phase B current.     | signed int16 fractional (scaling 1/10)    |
+| 102-103                  | 2 bytes  | Load Phase C current.     | signed int16 fractional (scaling 1/10)    |
+| 104-105                  | 2 bytes  | Load Power Factor         | signed int16 fractional (scaling 1/1000)  |
+| 106-107                  | 2 bytes  | Load active power.        | signed int16                              |
+| 108-109                  | 2 bytes  | Load reactive power.      | signed int16                              |
+| 110-111                  | 2 bytes  | Load apparent power.      | signed int16                              |
 
 ### **`0x0d00`: Get load information**
 **Request:** `fe 55 64 14 0d 00 00 d9 ae`

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -115,7 +115,7 @@ Battery states:
 
 **Request message:** `0x00`
 
-**Response message :**
+**Response message:**
 
 | Address in message block | Length   | Meaning                   | Data type                                 |
 |--------------------------|----------|---------------------------|-------------------------------------------|
@@ -161,50 +161,60 @@ Battery states:
 | 108-109                  | 2 bytes  | Load reactive power.      | signed int16                              |
 | 110-111                  | 2 bytes  | Load apparent power.      | signed int16                              |
 
-### **`0x0d00`: Get load information**
-**Request:** `fe 55 64 14 0d 00 00 d9 ae`
+### `0x0d00`: Get load information
+**Request example:** `fe 55 64 14 0d 00 00 d9 ae`
 
-**Response:**
-| Address | Meaning | Data type |
-| ------- | ------- | --------- |
-| 0x0B | Current load (power consumption). | uint16_t |
+**Request Message:** `0x00`
 
-### **`0x9500`: Get working parameters**
-**Request:** `fe 55 64 14 95 00 00 41 ae`
+**Response Message:**
 
-**Response:**
-| Address | Meaning | Data type |
-| ------- | ------- | --------- |
-| 0x0F | Upper limit of on-grid power. | uint16_t |
-| 0x13 | Working mode. | uint16_t (see note) |
-| 0x1D | Lower limit of on-grid SOC. | uint16_t |
+| Address in message block | Length  | Meaning                           | Data type    |
+|--------------------------|---------|-----------------------------------|--------------|
+| 3-4                      | 2 bytes | Current load (power consumption). | signed int16 |
+
+### `0x9500`: Get working parameters
+**Request Example:** `fe 55 64 14 95 00 00 41 ae`
+
+**Request Message:** `0x00`
+
+**Response Message:**
+
+| Address in message block | Length  | Meaning                       | Data type               |
+|--------------------------|---------|-------------------------------|-------------------------|
+| 0-7                      | 6 bytes | ??                            | ??                      |
+| 8-9                      | 2 bytes | Upper limit of on-grid power. | signed int16            |
+| 10-11                    | 2 bytes | ??                            | ??                      |
+| 12-13                    | 2 bytes | Working mode.                 | signed int16 (see note) |
+| 14-21                    | 8 bytes | ??                            | ??                      |
+| 22-23                    | 2 bytes | Lower limit of on-grid SOC.   | signed int16            |
 
 Working modes:
-- 0x0001: General Mode
-- 0x0002: Energy Storage Mode
+- `0x0001`: General Mode
+- `0x0002`: Energy Storage Mode
 - code for another three modes is unknown (unable to test)
 
-### **`0x6600`: Set working parameters**
+### `0x6600`: Set working parameters
 **Request:**
-| Address | Meaning | Content |
-| ------- | ------- | --------- |
-| 0x00 | Header. | `0xfe 0x55 0x64 0x14` |
-| 0x04 | Command. | `0x66 0x00` |
-| 0x06 | Size. | `0x20` |
-| 0x07-0x0E | Zeroes. | `00...` |
-| 0x0F | Upper limit of on-grid power. | value as uint16_t |
-| 0x11-0x12 | Zeroes. | `00...` |
-| 0x13 | Working mode. See note at `0x9500`. | value as uint16_t |
-| 0x15-0x18 | Zeroes. | `00...` |
-| 0x19 | Unknown. | `0x00ee` |
-| 0x1B-0x1C | Zeroes. | `00...` |
-| 0x1D | Lower limit of on-grid SOC. | value as uint16_t |
-| 0x1F | Unknown. | `0x0001` |
-| 0x21 | Unknown. | `0x0000` |
-| 0x23 | Unknown. | `0x059F` |
-| 0x25 | Unknown. | `0x0003` |
-| 0x27 | Checksum. | ? |
-| 0x28 | Footer. | `0xAE` |
+
+| Address   | Meaning                             | Content               |
+|-----------|-------------------------------------|-----------------------|
+| 0x00      | Header.                             | `0xfe 0x55 0x64 0x14` |
+| 0x04      | Command.                            | `0x66 0x00`           |
+| 0x06      | Size.                               | `0x20`                |
+| 0x07-0x0E | Zeroes.                             | `00...`               |
+| 0x0F      | Upper limit of on-grid power.       | value as uint16_t     |
+| 0x11-0x12 | Zeroes.                             | `00...`               |
+| 0x13      | Working mode. See note at `0x9500`. | value as uint16_t     |
+| 0x15-0x18 | Zeroes.                             | `00...`               |
+| 0x19      | Unknown.                            | `0x00ee`              |
+| 0x1B-0x1C | Zeroes.                             | `00...`               |
+| 0x1D      | Lower limit of on-grid SOC.         | value as uint16_t     |
+| 0x1F      | Unknown.                            | `0x0001`              |
+| 0x21      | Unknown.                            | `0x0000`              |
+| 0x23      | Unknown.                            | `0x059F`              |
+| 0x25      | Unknown.                            | `0x0003`              |
+| 0x27      | Checksum.                           | ?                     |
+| 0x28      | Footer.                             | `0xAE`                |
 
 **Response:** none
 
@@ -222,4 +232,10 @@ for every byte in data:
     checksum = checksum ⊻ byte
 ```
 
-Example: let's calculate a checksum for the battery information request. The header stays the same, the command is 0x0a followed by 0x00 and the message length is 0. The message looks like this: `fe 55 64 14 0a 00 00`. Checksum will be calculated using the formula above: 0f ⊻ fe ⊻ 55 ⊻ 64 ⊻ 14 ⊻ 0a ⊻ 00 ⊻ 00 = de. We will attach the checksum and the header to the message and we are finished: `fe 55 64 14 0a 00 00 de ae`.
+**Example:**
+
+Let's calculate a checksum for the battery information request.
+The header stays the same, the command is 0x0a followed by `0x00` and the message length is 0.
+The message looks like this: `fe 55 64 14 0a 00 00`.
+Checksum will be calculated using the formula above: `0f` ⊻ `fe` ⊻ `55` ⊻ `64` ⊻ `14` ⊻ `0a` ⊻ `00` ⊻ `00` = `de`.
+We will attach the checksum and the header to the message, and we are finished: `fe 55 64 14 0a 00 00 de ae`.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -61,6 +61,7 @@ Notes:
 | `0x6800`                | Send current date and time. |
 | `0x0a00`                | Get battery information.    |
 | `0x0b00`                | Get grid status.            |
+| `0xbb00`                | ?                           |
 | `0x0c00`                | ?                           |
 | `0x0d00`                | Get load information.       |
 | `0x9500`                | Get working parameters.     |
@@ -123,7 +124,6 @@ Battery states:
 | 4-5                      | 2 bytes  | PV1 power.              | unsigned int16                            |
 | 6-7                      | 2 bytes  | PV2 voltage.            | unsigned int16 fractional (scaling 1/10)  |
 | 8-9                      | 2 bytes  | PV2 current.            | unsigned int16 fractional (scaling 1/10)  |
-| 10-11                    | 2 bytes  | PV2 power.              | unsigned int16                            |
 | 10-11                    | 2 bytes  | PV2 power.              | unsigned int16                            |
 | 12-17                    | 6 bytes  | ??                      | ??                                        |
 | 18-19                    | 2 bytes  | AB line voltage         | unsigned int16 fractional (scaling 1/10)  |
@@ -202,7 +202,8 @@ Working modes:
 
 **Response:** none
 
-### **`0x1e00`: Error**
+### `0x1e00`: Error
+### `0xbb00`: Error
 
 ## Checksum
 The checksum is calculated with a simple formula: xor all bytes until the checksum byte position, then xor with `0f`.


### PR DESCRIPTION
Fixing https://github.com/andreondra/sermatec-inverter/issues/22

1. use universal type name
2. using the byte position in the response datagram
3. added empty space when there is address jump in the datagram... maybe something to dig in at this position...
4. specify data length

Still have work on this... creating the PR to get your feedback... 